### PR TITLE
Added Promise support for IPN

### DIFF
--- a/src/ipn.js
+++ b/src/ipn.js
@@ -1,49 +1,80 @@
-const
-	qs     = require('querystring'),
-	crypto = require('crypto');
+const qs     = require('querystring');
+const crypto = require('crypto');
 
-module.exports = (function () {
-
-	function IPN ({merchantId, merchantSecret}) {
-		if(!merchantId || !merchantSecret) {
-      throw "Merchant ID and Merchant Secret are needed";
-    }
-    let hmac;
-
-    let getPrivateHeadersIPN = function (parameters) {
-			let signature, paramString;
-
-			paramString = qs.stringify(parameters).replace(/%20/g, '+')
-
-	  	signature = crypto.createHmac('sha512', merchantSecret).update(paramString).digest('hex');
-
-	  	return signature;
+module.exports = (function ()
+{
+	function IPN({merchantId, merchantSecret})
+	{
+		if(!merchantId || !merchantSecret)
+		{
+			throw "Merchant ID and Merchant Secret are needed";
 		}
 
-    return (req,res,next) => {
-      if(!req.get('HMAC') || !req.body || !req.body.ipn_mode || req.body.ipn_mode != 'hmac' || merchantId != req.body.merchant) {
-        return next("COINPAYMENTS_INVALID_REQUEST");
-      }
-      hmac = getPrivateHeadersIPN(req.body);
-      if(hmac != req.get('HMAC')) {
-        return next("COINPAYMENTS_INVALID_REQUEST");
-      }
-      res.end();
-      if(req.body.status < 0) {
-        this.emit('ipn_fail', req.body);
-        return next();
-      }
-      if(req.body.status < 100){
-        this.emit('ipn_pending', req.body);
-        return next();
-      }
-      if(req.body.status == 100) {
-        this.emit('ipn_complete', req.body);
-        return next();
-      }
-    }
-	}
-	
-	return IPN;
+		function validateHMAC(parameters) 
+		{
+			let signature, paramString;
+			paramString = qs.stringify(parameters).replace(/%20/g, '+')
+			signature = crypto.createHmac('sha512', merchantSecret).update(paramString).digest('hex');
+			return signature;
+		}
 
+		let methods = {
+			validate: (ProvidedHMAC, ipnParams) =>
+			{
+				return new Promise((resolve, reject) => {
+
+					if(!ProvidedHMAC || !ipnParams || !ipnParams.ipn_mode || ipnParams.ipn_mode != 'hmac' || merchantId != ipnParams.merchant)
+					{
+						return resolve({success: false, message: "COINPAYMENTS_INVALID_REQUEST"});
+					}
+
+					let ComputedHMAC = this.validateHMAC(ipnParams);
+					if(ComputedHMAC != ProvidedHMAC)
+					{
+						return reject({success: false, message: "COINPAYMENTS_INVALID_REQUEST"});
+					}
+
+					if(ipnParams.status < 0)
+					{
+						return resolve({success: false, ipn: ipnParams, failed: true, message: "COINPAYMENTS_TRANSACTION_FAILED"});
+					}
+
+					if(ipnParams.status < 100)
+					{
+						return resolve({success: false, ipn: ipnParams, pending: true, message: "COINPAYMENTS_TRANSACTION_PENDING"});
+					}
+
+					if(ipnParams.status == 100)
+					{
+						return resolve({success: true, ipn: ipnParams});
+					}
+					return reject({success: false, message: "COINPAYMENTS_UNKOWN_REQUEST"});
+				});
+			},
+			middleware: (req, res, next) =>
+			{
+				methods.verify(req.get("HMAC"), req.body).then( result => {
+					if(result.success)
+					{
+						this.emit('ipn_complete', req.body);
+					}
+					
+					if(result.pending)
+					{
+						this.emit('ipn_pending', req.body);
+					}
+
+					if(result.failed)
+					{
+						this.emit('ipn_fail', req.body);
+					}
+					return next();
+				}).catch( error => {
+					return next(error.message);
+				});
+			}
+		};
+		return methods;
+	}
+	return IPN;
 })();


### PR DESCRIPTION
Related issue: https://github.com/OrahKokos/coinpayments/issues/5

- Added Promise support for IPN

**Note:** coinpayments.ipn returns an object instead of a function
```javascript
ipn.middleware // Middleware version to verify coinpayments ipn requests
ipn.verify // Returns a promise and accepts, GET HMAC key and IPN POST
body

```
- Updated examples

Example usage:

```javascript
// Handle IPN with Promise
app.post("/mycustomurl", (req, res) => {
	let ipn = CoinPayments.ipn({
		'merchantId': process.env.COINPAYMENTS_MERCHANT_ID,
		'merchantSecret': process.env.COINPAYMENTS_MERCHANT_SECRET
	});
	
	// Retrieve HMAC from the request url
	ipn.verify(req.get("HMAC"), req.body).then( result => {
		if(result.success)
		{
			console.log("I got paid!");
		}
		
		if(result.pending)
		{
			console.log("My Payment is pending...");
		}

		if(result.failed)
		{
			console.log("My payment has failed");
		}
	}).catch( error => {
		console.log("Woops! Invalid request?!");
	});
})

```

That would be it.