### PR TITLE
CoinPayments 'Complete' IPN never goes through (#18)

### DIFF
--- a/src/ipn.js
+++ b/src/ipn.js
@@ -38,7 +38,7 @@ module.exports = (function () {
                 this.emit('ipn_pending', req.body);
                 return next();
             }
-            if(req.body.status === 100) {
+            if(req.body.status == 100) {
                 this.emit('ipn_complete', req.body);
                 return next();
             }

--- a/src/ipn.js
+++ b/src/ipn.js
@@ -48,3 +48,4 @@ module.exports = (function () {
     return IPN;
 
 })();
+


### PR DESCRIPTION
CoinPayments sends status as a String, not a Number. 